### PR TITLE
Update cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import parse from "node:path";
+import { parse } from "node:path";
 import process from "node:process";
 import chalk from "chalk";
 import { globby } from "globby";


### PR DESCRIPTION
TypeError: parse is not a function
    at file:///home/node/app/node_modules/mock-to-openapi/cli.js:56:38

Node.js v22.11.0
cat: src/swagger/schemas/equipment.curl.yaml: No such file or directory file:///home/node/app/node_modules/mock-to-openapi/cli.js:56
			const output = `${cli.input[1] || parse(file).dir}/${parse(file).name}.yaml`;
			                                  ^

TypeError: parse is not a function
    at file:///home/node/app/node_modules/mock-to-openapi/cli.js:56:38

Node.js v22.11.0